### PR TITLE
Disable wgx-smoke workflow with manual noop job

### DIFF
--- a/.github/workflows/wgx-smoke.yml
+++ b/.github/workflows/wgx-smoke.yml
@@ -1,7 +1,7 @@
 name: wgx-smoke (disabled)
 on:
-  # Nur noch manuell startbar, damit die Datei gültig bleibt,
-  # aber im normalen CI nicht mehr „rot“ erscheint.
+  # Only manually startable to keep the file valid,
+  # but no longer appears "red" in normal CI.
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/wgx-smoke.yml
+++ b/.github/workflows/wgx-smoke.yml
@@ -1,3 +1,12 @@
 name: wgx-smoke (disabled)
-on: {}
-jobs: {}
+on:
+  # Nur noch manuell startbar, damit die Datei gültig bleibt,
+  # aber im normalen CI nicht mehr „rot“ erscheint.
+  workflow_dispatch: {}
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report disabled status
+        run: echo "wgx-smoke workflow is intentionally disabled (noop)."


### PR DESCRIPTION
## Summary
- restrict the `wgx-smoke` workflow to manual runs only
- replace the empty jobs section with a noop job that reports the disabled status

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0a6168b0c832c819ecba90e05ddae