### PR TITLE
Remove duplicate dev dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ python-preference = "managed"
 python-version = "3.10"
 
 [project.optional-dependencies]
-## Hinweis:
-## Dev-Tools werden nur noch hier unter den PEP 621-konformen Extras gepflegt.
+## Note:
+## Dev tools are now only maintained here under the PEP 621-compliant extras.
 ## Installation:
 ##   - uv:  `uv sync --extra dev`
 ##   - pip: `pip install .[dev]`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,19 +10,12 @@ managed = true
 python-preference = "managed"
 python-version = "3.10"
 
-[dependency-groups]
-dev = [
-  "ruff>=0.6",
-  "pre-commit>=3.8",
-  "mkdocs>=1.6",
-  "mkdocs-material>=9.5",
-  "mkdocs-minify-plugin>=0.8",
-  "mkdocs-git-revision-date-localized-plugin>=1.3",
-  "pytest>=8.3",
-  "rich>=13.9"
-]
-
 [project.optional-dependencies]
+## Hinweis:
+## Dev-Tools werden nur noch hier unter den PEP 621-konformen Extras gepflegt.
+## Installation:
+##   - uv:  `uv sync --extra dev`
+##   - pip: `pip install .[dev]`
 dev = [
   "ruff>=0.6",
   "pre-commit>=3.8",


### PR DESCRIPTION
## Summary
- remove the redundant [dependency-groups] dev section from pyproject.toml
- document that dev tooling is managed exclusively via the PEP 621 optional dependency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0a91cd63c832cab5024ad9dc391fe