### PR TITLE
Fix uv python version field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.uv]
 managed = true
 python-preference = "managed"
-python-version = "3.10"
+required-version = "3.10"
 
 [project.optional-dependencies]
 ## Note:


### PR DESCRIPTION
## Summary
- replace the invalid `python-version` field in the `[tool.uv]` configuration with `required-version` to resolve the build error

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0a9a73018832c8ea6cc4787c5ed58