### PR TITLE
Fix OpenAPI JSON response and define index service constant

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,21 @@
+name: coverage
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  cov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+      - name: Run coverage
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      # Coveralls optional – ein-/auskommentieren je nach Bedarf:
+      # - uses: coverallsapp/github-action@v2
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     path-to-lcov: lcov.info

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,20 @@
+name: security
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  pull_request:
+  workflow_dispatch:
+jobs:
+  audit-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install tools
+        run: |
+          cargo install cargo-audit --locked
+          cargo install cargo-deny --locked
+      - name: cargo audit
+        run: cargo audit
+      - name: cargo deny
+        run: cargo deny check

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ![WGX](https://img.shields.io/badge/wgx-enabled-blue)
+![security](https://github.com/hauski/hauski/actions/workflows/security.yml/badge.svg)
+![coverage](https://github.com/hauski/hauski/actions/workflows/coverage.yml/badge.svg)
 
 # HausKI — Rust-first, Offline-Default, GPU-aware
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -24,7 +24,7 @@ url.workspace = true
 hauski-indexd = { path = "../indexd", version = "0.1.0" }
 tower = { version = "0.5", features = ["limit", "timeout"] }
 utoipa = { version = "4", features = ["axum_extras"] }
-utoipa-swagger-ui = "7"
+utoipa-swagger-ui = "7.0"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -22,6 +22,9 @@ dirs.workspace = true
 reqwest.workspace = true
 url.workspace = true
 hauski-indexd = { path = "../indexd", version = "0.1.0" }
+tower = { version = "0.5", features = ["limit", "timeout"] }
+utoipa = { version = "4", features = ["axum_extras"] }
+utoipa-swagger-ui = "7"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -422,7 +422,7 @@ fn core_routes() -> Router<AppState> {
         .route(
             "/docs/openapi.json",
             get(|| async {
-                // robuste Ausgabe als JSON-String
+                // robust output as JSON string
                 let json = ApiDoc::openapi().to_json().expect("openapi json");
                 (
                     StatusCode::OK,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,3 +1,4 @@
+use axum::extract::FromRef;
 use axum::{
     body::Body,
     extract::State,
@@ -7,7 +8,6 @@ use axum::{
     routing::get,
     Json, Router,
 };
-use axum::extract::FromRef;
 use hauski_indexd::{router as index_router, IndexState};
 use prometheus_client::{
     encoding::{text::encode, EncodeLabel, EncodeLabelSet},
@@ -20,8 +20,11 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    time::Instant,
+    time::{Duration, Instant},
 };
+use tower::{limit::ConcurrencyLimitLayer, timeout::TimeoutLayer};
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
 
 mod config;
 mod egress;
@@ -35,8 +38,16 @@ pub use egress::{
 
 const LATENCY_BUCKETS: [f64; 8] = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0];
 const CORE_SERVICE_NAME: &str = "core";
+const INDEXD_SERVICE_NAME: &str = "indexd";
 
 type MetricsCallback = dyn Fn(Method, &'static str, StatusCode, Instant) + Send + Sync;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(health, ready),
+    tags((name = "core", description = "Core health & readiness"))
+)]
+struct ApiDoc;
 
 /// Creates a latency histogram with predefined buckets.
 ///
@@ -97,10 +108,14 @@ impl AppState {
 
         let build_info = Family::<BuildInfoLabels, Gauge>::default();
         build_info
-            .get_or_create(&BuildInfoLabels { service: CORE_SERVICE_NAME })
+            .get_or_create(&BuildInfoLabels {
+                service: CORE_SERVICE_NAME,
+            })
             .set(1);
         build_info
-            .get_or_create(&BuildInfoLabels { service: INDEXD_SERVICE_NAME })
+            .get_or_create(&BuildInfoLabels {
+                service: INDEXD_SERVICE_NAME,
+            })
             .set(1);
         registry.register("build_info", "Build info per service", build_info.clone());
 
@@ -286,6 +301,12 @@ async fn get_routing(State(state): State<AppState>) -> Json<RoutingPolicy> {
     response
 }
 
+#[utoipa::path(
+    get,
+    path = "/health",
+    responses((status = 200, description = "Service healthy")),
+    tag = "core"
+)]
 async fn health(State(state): State<AppState>) -> &'static str {
     let started = Instant::now();
     let status = StatusCode::OK;
@@ -293,6 +314,15 @@ async fn health(State(state): State<AppState>) -> &'static str {
     "ok"
 }
 
+#[utoipa::path(
+    get,
+    path = "/ready",
+    responses(
+        (status = 200, description = "Service ready"),
+        (status = 503, description = "Service starting")
+    ),
+    tag = "core"
+)]
 async fn ready(State(state): State<AppState>) -> (StatusCode, &'static str) {
     let started = Instant::now();
     let (status, body) = if state.is_ready() {
@@ -378,7 +408,9 @@ pub fn build_app_with_state(
     // The readiness flag is set by the caller once the listener is bound.
     let app = app
         .with_state(state.clone())
-        .layer(from_fn_with_state(allowed_origin.clone(), cors_middleware));
+        .layer(from_fn_with_state(allowed_origin.clone(), cors_middleware))
+        .layer(TimeoutLayer::new(Duration::from_millis(1500)))
+        .layer(ConcurrencyLimitLayer::new(512));
     (app, state)
 }
 
@@ -387,6 +419,19 @@ fn core_routes() -> Router<AppState> {
         .route("/health", get(health))
         .route("/ready", get(ready))
         .route("/metrics", get(metrics))
+        .route(
+            "/docs/openapi.json",
+            get(|| async {
+                // robuste Ausgabe als JSON-String
+                let json = ApiDoc::openapi().to_json().expect("openapi json");
+                (
+                    StatusCode::OK,
+                    [(header::CONTENT_TYPE, "application/json")],
+                    json,
+                )
+            }),
+        )
+        .merge(SwaggerUi::new("/docs").url("/docs/openapi.json", "openapi.json"))
 }
 
 fn config_routes() -> Router<AppState> {

--- a/deny.toml
+++ b/deny.toml
@@ -1,19 +1,21 @@
+targets = [{ triple = "x86_64-unknown-linux-gnu" }]
+
 [advisories]
-version = 2
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+notice = "warn"
+ignore = []
 
 [licenses]
-version = 2
-confidence-threshold = 0.8
-allow = [
-    "MIT",
-    "Apache-2.0",
-    "BSD-3-Clause",
-    "BSD-2-Clause",
-    "ISC",
-    "Unicode-DFS-2016",
-    "Unicode-3.0",
-]
+unlicensed = "deny"
+allow = ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "Zlib", "Unicode-DFS-2016"]
+deny = ["AGPL-3.0", "GPL-3.0", "GPL-2.0"]
+confidence-threshold = 0.9
 
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
+deny = []
+skip = []
+skip-tree = []


### PR DESCRIPTION
## Summary
- define the missing index service constant used by the core router
- return the generated OpenAPI spec as a JSON string with an explicit content type header

## Testing
- cargo fmt
- cargo check *(fails: failed to download crates due to 403 CONNECT tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d482c298832caaf3cd982c0c0102