### PR TITLE
Add timeout and caching to security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   audit-deny:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -14,7 +15,12 @@ jobs:
         run: |
           cargo install cargo-audit --locked
           cargo install cargo-deny --locked
+      - name: Cache cargo-audit DB
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/advisory-db
+          key: ${{ runner.os }}-advisory-db
       - name: cargo audit
-        run: cargo audit
+        run: cargo audit --timeout 60
       - name: cargo deny
         run: cargo deny check


### PR DESCRIPTION
## Summary
- add a job-level timeout to the security workflow and limit cargo audit network time
- cache the cargo-audit advisory database to avoid repeated downloads

## Testing
- not run (CI workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e19ff040fc832ca0ac99a84bcce7bd