### PR TITLE
Improve security workflow caching and timeouts

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/advisory-db
-          key: ${{ runner.os }}-advisory-db
+          # Stabiler Key mit Restore-Präfix; Frische wird durch 'cargo audit fetch' sichergestellt
+          key: ${{ runner.os }}-advisory-db-v1
+          restore-keys: |
+            ${{ runner.os }}-advisory-db-
+      - name: Update advisory DB
+        run: |
+          # Aktualisiert die RustSec-Datenbank nach Cache-Restore, um Staleness zu vermeiden
+          cargo audit fetch
       - name: cargo audit
         run: cargo audit --timeout 60
       - name: cargo deny


### PR DESCRIPTION
## Summary
- add restore keys and a versioned cache key for the cargo-audit advisory database
- refresh the advisory database after restoring the cache to prevent stale data

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e1a1e44614832cb8ba11f0c99e1492