### PR TITLE
Ensure index budget gate job checks out repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
        (needs.changes.outputs.rust == 'true' || contains(join(github.event.pull_request.labels.*.name), 'full-ci')))
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5
       - name: Emit TODO notice
         run: |
           sudo apt-get update && sudo apt-get install -y shellcheck


### PR DESCRIPTION
## Summary
- add an explicit checkout step to the index budget gate job so shellcheck runs against the repository contents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1a2fb4924832caf7c60ed0f8be915