### PR TITLE
Improve coverage workflow performance

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,19 +1,44 @@
 name: coverage
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/coverage.yml"
   workflow_dispatch:
 jobs:
   cov:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    timeout-minutes: 12
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+      - name: Cache cargo + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: ${{ runner.os }}-cov-${{ hashFiles('**/Cargo.lock') }}
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
-      - name: Run coverage
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - name: Run coverage (focused)
+        env:
+          # genügt für llvm-cov, ist etwas schneller als debuginfo=2
+          RUSTFLAGS: "-C debuginfo=1"
+        run: |
+          # nur die runtime-relevanten Crates messen
+          PKGS="--package hauski-core --package hauski-indexd"
+          cargo llvm-cov $PKGS --lcov --output-path lcov.info
+      - name: Upload lcov
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov.info
+          path: lcov.info
       # Coveralls optional – ein-/auskommentieren je nach Bedarf:
       # - uses: coverallsapp/github-action@v2
       #   with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
         run: cargo install cargo-llvm-cov --locked --version 0.6.9
       - name: Run coverage (focused)
         env:
-          # genügt für llvm-cov, ist etwas schneller als debuginfo=2
+          # sufficient for llvm-cov; slightly faster than debuginfo=2
           RUSTFLAGS: "-C debuginfo=1"
         run: |
           # nur die runtime-relevanten Crates messen

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
           # sufficient for llvm-cov; slightly faster than debuginfo=2
           RUSTFLAGS: "-C debuginfo=1"
         run: |
-          # nur die runtime-relevanten Crates messen
+          # measure only the runtime-relevant crates
           PKGS="--package hauski-core --package hauski-indexd"
           cargo llvm-cov $PKGS --lcov --output-path lcov.info
       - name: Upload lcov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   cov:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          key: ${{ runner.os }}-cov-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: ${{ runner.os }}-cov-${{ hashFiles('**/Cargo.lock') }}
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
       - name: Run coverage (focused)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
           cache-on-failure: true
           shared-key: ${{ runner.os }}-cov-${{ hashFiles('**/Cargo.lock') }}
       - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --locked
+        run: cargo install cargo-llvm-cov --locked --version 0.6.9
       - name: Run coverage (focused)
         env:
           # genügt für llvm-cov, ist etwas schneller als debuginfo=2


### PR DESCRIPTION
## Summary
- restrict the coverage workflow to relevant Rust changes and skip draft pull requests
- add caching, timeouts, and focused package selection to speed up coverage collection
- upload the generated lcov.info artifact for downstream consumption

## Testing
- not run (CI workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e1a6ac6268832ca406ed69dff40f91