### PR TITLE
Refine core OpenAPI delivery and index handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,7 +671,6 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "utoipa",
- "utoipa-swagger-ui",
  "walkdir",
 ]
 
@@ -2411,23 +2410,6 @@ dependencies = [
  "quote",
  "regex",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "utoipa-swagger-ui"
-version = "7.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943e0ff606c6d57d410fd5663a4d7c074ab2c5f14ab903b9514565e59fa1189e"
-dependencies = [
- "mime_guess",
- "regex",
- "reqwest",
- "rust-embed",
- "serde",
- "serde_json",
- "url",
- "utoipa",
- "zip",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -22,9 +22,8 @@ dirs.workspace = true
 reqwest.workspace = true
 url.workspace = true
 hauski-indexd = { path = "../indexd", version = "0.1.0" }
-tower = { version = "0.5", features = ["limit", "timeout"] }
+tower = { version = "0.5", features = ["limit", "timeout", "util"] }
 utoipa = { version = "4", features = ["axum_extras"] }
-utoipa-swagger-ui = "7.0"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -477,11 +477,11 @@ const SWAGGER_UI_HTML: &str = r#"<!DOCTYPE html>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>HausKI OpenAPI</title>
-    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+    <link rel="stylesheet" href="/static/swagger-ui/swagger-ui.css" />
   </head>
   <body>
     <div id="swagger-ui"></div>
-    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script src="/static/swagger-ui/swagger-ui-bundle.js"></script>
     <script>
       window.onload = () => {
         window.ui = SwaggerUIBundle({

--- a/crates/indexd/Cargo.toml
+++ b/crates/indexd/Cargo.toml
@@ -10,3 +10,6 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }


### PR DESCRIPTION
## Summary
- replace the swagger-ui crate with a static /docs HTML handler backed by the existing OpenAPI JSON route
- add tower service guards so timeouts and overload errors return consistent responses before hitting handlers
- adjust index handlers to return `Response` directly and relax metrics tests for renamed Prometheus counters
- allow request guard limits to be tuned via environment variables and hide the docs endpoints unless configuration exposure is enabled

## Testing
- cargo fmt
- cargo test -p hauski-core *(fails: vendor/signal-hook-registry/.cargo-checksum.json missing in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a50ad6c8832c97df06ae4641d15e