### PR TITLE
Fix invalid escape in rust problem matcher

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -15,7 +15,7 @@
           "column": 3
         },
         {
-          "regexp": "^\\s*\|.*$",
+          "regexp": "^\\s*|.*$",
           "loop": true
         }
       ]
@@ -35,7 +35,7 @@
           "column": 3
         },
         {
-          "regexp": "^\\s*\|.*$",
+          "regexp": "^\\s*|.*$",
           "loop": true
         }
       ]


### PR DESCRIPTION
## Summary
- remove the unnecessary escape for the pipe symbol in the custom rust problem matcher
- ensure the JSON problem matcher file parses correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e20031b51c832c957938cc599501d3