### PR TITLE
Improve workflow concurrency and caching

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,13 +25,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
-      - name: Cache llvm tools
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/llvm
-          key: llvm-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            llvm-${{ runner.os }}-
       - name: Cache cargo + target
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,17 +7,31 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/coverage.yml"
+  push:
+    branches: [ main ]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cov:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    timeout-minutes: 12
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+      - name: Cache llvm tools
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/llvm
+          key: llvm-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            llvm-${{ runner.os }}-
       - name: Cache cargo + target
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,11 +3,18 @@ on:
   schedule:
     - cron: "0 3 * * *"
   pull_request:
+  push:
+    branches: [ main ]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   audit-deny:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -19,15 +26,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/advisory-db
-          # Stable key with restore prefix; freshness is ensured by 'cargo audit fetch'
-          key: ${{ runner.os }}-advisory-db-v1
+          key: ${{ runner.os }}-advisory-db-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-advisory-db-
       - name: Update advisory DB
         run: |
           # Updates the RustSec database after cache restore to avoid staleness
-          cargo audit fetch
+          timeout 120s cargo audit fetch || true
       - name: cargo audit
-        run: cargo audit --timeout 60
+        run: cargo audit -D warnings --timeout 60
       - name: cargo deny
         run: cargo deny check

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,7 +32,14 @@ jobs:
       - name: Update advisory DB
         run: |
           # Updates the RustSec database after cache restore to avoid staleness
-          timeout 120s cargo audit fetch || true
+          timeout 120s cargo audit fetch
+          status=$?
+          if [ $status -eq 124 ]; then
+            echo "cargo audit fetch timed out (exit code 124), continuing with possibly stale advisory DB."
+          elif [ $status -ne 0 ]; then
+            echo "cargo audit fetch failed with exit code $status"
+            exit $status
+          fi
       - name: cargo audit
         run: cargo audit -D warnings --timeout 60
       - name: cargo deny


### PR DESCRIPTION
## Summary
- run coverage workflow on pushes while cancelling superseded runs and extend timeout for heavy coverage builds
- cache llvm toolchain downloads to avoid repeated installs
- ensure security workflow cancels superseded runs, uses rolling advisory cache, and tightens cargo-audit checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e200abe384832cbac709803ef8d54e