### PR TITLE
Add missing checksum for vendored signal-hook-registry

### DIFF
--- a/vendor/signal-hook-registry/.cargo-checksum.json
+++ b/vendor/signal-hook-registry/.cargo-checksum.json
@@ -1,0 +1,7 @@
+{
+  "files": {
+    "Cargo.toml": "f00842a7eddaf3d705d80e2018ba3711832c89c59fed4d840d7eb144d3e565a4",
+    "src/lib.rs": "cd1a5ba4321ae4aa515932805014c18e847f20af36b4a0fdfe032b4b5e5ca60a"
+  },
+  "package": ""
+}


### PR DESCRIPTION
## Summary
- add the missing `.cargo-checksum.json` for the vendored `signal-hook-registry` crate so cargo can read the dependency metadata again

## Testing
- `cargo check -p hauski-core` *(fails: proxy blocked access to crates.io index in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e200e22ef4832c92afd55f86f2ee5d