### PR TITLE
Fix escaping of pipe in rust problem matcher

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -15,7 +15,7 @@
           "column": 3
         },
         {
-          "regexp": "^\\s*|.*$",
+          "regexp": "^\\s*\\|.*$",
           "loop": true
         }
       ]
@@ -35,7 +35,7 @@
           "column": 3
         },
         {
-          "regexp": "^\\s*|.*$",
+          "regexp": "^\\s*\\|.*$",
           "loop": true
         }
       ]


### PR DESCRIPTION
## Summary
- escape the literal pipe character in the rust problem matcher regex so it no longer triggers alternation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e204d6bc48832c93de54760c7f282b