### PR TITLE
Handle OpenAPI serialization errors

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -519,7 +519,7 @@ async fn openapi_json() -> Response {
             tracing::error!("failed to serialize OpenAPI JSON: {err}");
             // Compact JSON error payload for clients.
             let body = format!(
-                "{{\"error\":\"failed to render openapi\",\"details\":\"{}\"}}",
+                "{{\"error\":\"failed to serialize openapi\",\"details\":\"{}\"}}",
                 err
             );
             (

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -465,10 +465,9 @@ fn core_routes() -> Router<AppState> {
 }
 
 fn docs_routes() -> Router<AppState> {
-    Router::new().route("/docs", get(api_docs)).route(
-        "/docs/openapi.json",
-        get(|| async { Json(ApiDoc::openapi()) }),
-    )
+    Router::new()
+        .route("/docs", get(api_docs))
+        .route("/docs/openapi.json", get(openapi_json))
 }
 
 const SWAGGER_UI_HTML: &str = r#"<!DOCTYPE html>
@@ -497,6 +496,43 @@ const SWAGGER_UI_HTML: &str = r#"<!DOCTYPE html>
 
 async fn api_docs() -> Html<&'static str> {
     Html(SWAGGER_UI_HTML)
+}
+
+/// Serve OpenAPI as JSON with robust error handling.
+async fn openapi_json() -> Response {
+    // 1) Build the OpenAPI struct (infallible in `utoipa`).
+    let spec = ApiDoc::openapi();
+
+    // 2) Serialize explicitly so we can handle failures gracefully.
+    match serde_json::to_vec(&spec) {
+        Ok(bytes) => (
+            StatusCode::OK,
+            [(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            )],
+            bytes,
+        )
+            .into_response(),
+        Err(err) => {
+            // Log for operators.
+            tracing::error!("failed to serialize OpenAPI JSON: {err}");
+            // Compact JSON error payload for clients.
+            let body = format!(
+                "{{\"error\":\"failed to render openapi\",\"details\":\"{}\"}}",
+                err
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static("application/json"),
+                )],
+                body,
+            )
+                .into_response()
+        }
+    }
 }
 
 fn config_routes() -> Router<AppState> {


### PR DESCRIPTION
## Summary
- replace the inline OpenAPI endpoint closure with a dedicated handler
- serialize the specification explicitly and log/return a 500 JSON payload if serialization fails

## Testing
- cargo fmt
- cargo check -p hauski-core *(fails: vendor checksum missing for signal-hook-registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e2004318b4832c8482657c45b38ec4