### PR TITLE
Fix security workflow cargo audit update command

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Update advisory DB
         run: |
           # Updates the RustSec database after cache restore to avoid staleness
-          timeout 120s cargo audit fetch
+          timeout 120s cargo audit --db-update
           status=$?
           if [ $status -eq 124 ]; then
-            echo "cargo audit fetch timed out (exit code 124), continuing with possibly stale advisory DB."
+            echo "cargo audit --db-update timed out (exit code 124), continuing with possibly stale advisory DB."
           elif [ $status -ne 0 ]; then
-            echo "cargo audit fetch failed with exit code $status"
+            echo "cargo audit --db-update failed with exit code $status"
             exit $status
           fi
       - name: cargo audit


### PR DESCRIPTION
## Summary
- replace the deprecated `cargo audit fetch` command with `cargo audit --db-update`
- keep timeout handling and messaging aligned with the updated command

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e20796f1e4832c9b331dde3aba98dc