### PR TITLE
Fix cargo audit workflow command

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Update advisory DB
         run: |
           # Updates the RustSec database after cache restore to avoid staleness
-          timeout 120s cargo audit fetch
+          timeout 120s cargo audit update
           status=$?
           if [ $status -eq 124 ]; then
-            echo "cargo audit fetch timed out (exit code 124), continuing with possibly stale advisory DB."
+            echo "cargo audit update timed out (exit code 124), continuing with possibly stale advisory DB."
           elif [ $status -ne 0 ]; then
-            echo "cargo audit fetch failed with exit code $status"
+            echo "cargo audit update failed with exit code $status"
             exit $status
           fi
       - name: cargo audit


### PR DESCRIPTION
## Summary
- replace the deprecated `cargo audit fetch` command in the security workflow with `cargo audit update`
- adjust log messages to reflect the new command name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e209724b00832c986009b25fcd7acd