### PR TITLE
Fix pipe escaping in rust problem matcher

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -15,7 +15,7 @@
           "column": 3
         },
         {
-          "regexp": "^\\s*\\|.*$",
+          "regexp": "^\\s*[|].*$",
           "loop": true
         }
       ]
@@ -35,7 +35,7 @@
           "column": 3
         },
         {
-          "regexp": "^\\s*\\|.*$",
+          "regexp": "^\\s*[|].*$",
           "loop": true
         }
       ]


### PR DESCRIPTION
## Summary
- replace the escaped pipe sequence in the rust problem matcher with a character class so JSON parsing succeeds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e20ba4e6f8832c8491a8fef9c35bb4