### PR TITLE
Update security workflow for cargo-audit update command

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Update advisory DB
         run: |
           # Updates the RustSec database after cache restore to avoid staleness
-          timeout 120s cargo audit --db-update
+          timeout 120s cargo audit update
           status=$?
           if [ $status -eq 124 ]; then
-            echo "cargo audit --db-update timed out (exit code 124), continuing with possibly stale advisory DB."
+            echo "cargo audit update timed out (exit code 124), continuing with possibly stale advisory DB."
           elif [ $status -ne 0 ]; then
-            echo "cargo audit --db-update failed with exit code $status"
+            echo "cargo audit update failed with exit code $status"
             exit $status
           fi
       - name: cargo audit


### PR DESCRIPTION
## Summary
- replace the deprecated `cargo audit --db-update` invocation with the supported `cargo audit update`
- keep timeout handling so the workflow continues gracefully if the update stalls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e20bfeb51c832ca76a696ad6cd016f