### PR TITLE
Fix Cargo.lock vendored path metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,6 @@ dependencies = [
 [[package]]
 name = "anyhow"
 version = "1.0.100"
-source = "path+vendor/anyhow"
 
 [[package]]
 name = "arbitrary"

--- a/vendor/signal-hook-registry/.cargo-checksum.json
+++ b/vendor/signal-hook-registry/.cargo-checksum.json
@@ -3,5 +3,5 @@
     "Cargo.toml": "f00842a7eddaf3d705d80e2018ba3711832c89c59fed4d840d7eb144d3e565a4",
     "src/lib.rs": "cd1a5ba4321ae4aa515932805014c18e847f20af36b4a0fdfe032b4b5e5ca60a"
   },
-  "package": ""
-}{"files":{"Cargo.toml":"f00842a7eddaf3d705d80e2018ba3711832c89c59fed4d840d7eb144d3e565a4","src/lib.rs":"cd1a5ba4321ae4aa515932805014c18e847f20af36b4a0fdfe032b4b5e5ca60a"},"package":null}
+  "package": null
+}


### PR DESCRIPTION
## Summary
- remove the invalid source URL for the vendored `anyhow` crate so Cargo can parse the lock file
- repair the corrupted `.cargo-checksum.json` file for the vendored `signal-hook-registry`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e20bf94bfc832c9e56ebda481de5e3