### PR TITLE
Fix cargo audit command in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Update advisory DB
         run: |
           # Updates the RustSec database after cache restore to avoid staleness
-          timeout 120s cargo audit update
+          timeout 120s cargo audit fetch
           status=$?
           if [ $status -eq 124 ]; then
-            echo "cargo audit update timed out (exit code 124), continuing with possibly stale advisory DB."
+            echo "cargo audit fetch timed out (exit code 124), continuing with possibly stale advisory DB."
           elif [ $status -ne 0 ]; then
-            echo "cargo audit update failed with exit code $status"
+            echo "cargo audit fetch failed with exit code $status"
             exit $status
           fi
       - name: cargo audit


### PR DESCRIPTION
## Summary
- replace the deprecated `cargo audit update` invocation with `cargo audit fetch`
- align related log messages with the new command name

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e20df7552c832c98d20d7713e46f1c