### PR TITLE
Guard devcontainer setup from missing cargo env

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -5,7 +5,10 @@ sudo apt-get update -y
 # Rust toolchain (if feature didn't handle fully)
 if ! command -v rustup >/dev/null 2>&1; then
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-  source "$HOME/.cargo/env"
+  if [ -f "$HOME/.cargo/env" ]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.cargo/env"
+  fi
 fi
 rustup component add clippy rustfmt
 


### PR DESCRIPTION
## Summary
- ensure the devcontainer setup script only sources the cargo environment file when it exists
- add a shellcheck directive to suppress warnings when the file is absent

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e20e3fe1ec832ca1d0c16d27cf8698