### PR TITLE
Fix CI doc and shell job filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,11 @@ jobs:
       (github.event_name == 'merge_group') ||
       (github.event_name != 'merge_group' &&
        github.event.pull_request.draft == false &&
-       (needs.changes.outputs.rust == 'true' || contains(join(github.event.pull_request.labels.*.name), 'full-ci')))
+       (
+         needs.changes.outputs.docs == 'true' ||
+         needs.changes.outputs.sh == 'true' ||
+         contains(join(github.event.pull_request.labels.*.name), 'full-ci')
+       ))
     runs-on: ubuntu-latest
     env:
       toolchain: stable
@@ -108,7 +112,10 @@ jobs:
       (github.event_name == 'merge_group') ||
       (github.event_name != 'merge_group' &&
        github.event.pull_request.draft == false &&
-       (needs.changes.outputs.rust == 'true' || contains(join(github.event.pull_request.labels.*.name), 'full-ci')))
+       (
+         needs.changes.outputs.sh == 'true' ||
+         contains(join(github.event.pull_request.labels.*.name), 'full-ci')
+       ))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- ensure the repo-lint job runs for documentation and shell changes
- gate the index budget check on shell changes instead of rust changes

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e218685ba8832cba11ad7ac74129e6