### PR TITLE
Fix GitHub Actions rust matcher loop message definition

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -15,8 +15,9 @@
           "column": 3
         },
         {
-          "regexp": "^\\s*[|].*$",
-          "loop": true
+          "regexp": "^(\\s*[|].*)$",
+          "loop": true,
+          "message": 1
         }
       ]
     },
@@ -35,8 +36,9 @@
           "column": 3
         },
         {
-          "regexp": "^\\s*[|].*$",
-          "loop": true
+          "regexp": "^(\\s*[|].*)$",
+          "loop": true,
+          "message": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary
- ensure each loop pattern in the Rust problem matcher sets a message group for GitHub Actions compatibility

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e2507e6ad4832c95c7ca6594b8ebc0