### PR TITLE
Fix cargo deny invocation in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,5 +179,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - name: cargo deny (advisories/bans/licenses)
+        run: |
+          cargo deny check advisories
+          cargo deny check bans
+          cargo deny check licenses
       - uses: rustsec/audit-check@v2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,15 +35,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check
-          # No --disable-fetch -> keeps advisory/index data fresh
-          arguments: >
-            advisories
-            bans
-            licenses
+      - name: cargo deny (advisories/bans/licenses)
+        run: |
+          cargo deny check advisories
+          cargo deny check bans
+          cargo deny check licenses
   audit:
     name: cargo-audit (CVE Check)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- update the security workflow to invoke `cargo deny check` explicitly for advisories, bans, and licenses
- align the main CI workflow with the new `cargo deny check` usage to avoid the invalid `cargo-deny` subcommand

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e25083f114832c992ee4e58db4683d