### PR TITLE
Fix rust problem matcher loop patterns

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -16,7 +16,8 @@
         },
         {
           "regexp": "^\\s*[|].*$",
-          "loop": true
+          "loop": true,
+          "message": 3
         }
       ]
     },
@@ -36,7 +37,8 @@
         },
         {
           "regexp": "^\\s*[|].*$",
-          "loop": true
+          "loop": true,
+          "message": 3
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add missing message attribute to looping rust problem matcher patterns

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e252a6c498832c9f6db129170a9931