### PR TITLE
Simplify cargo-deny setup in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,5 +179,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - name: cargo deny (advisories/bans/licenses)
+        run: |
+          cargo deny check advisories
+          cargo deny check bans
+          cargo deny check licenses
       - uses: rustsec/audit-check@v2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,29 +35,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Cache cargo-deny binary
-        id: cache-cargo-deny
-        uses: actions/cache@v4
+      - uses: taiki-e/install-action@v2
         with:
-          path: ~/.cargo-deny-bin
-          key: cargo-deny-bin-v0.14.20 # Update version as needed
-      - name: Download cargo-deny binary if not cached
-        if: steps.cache-cargo-deny.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/.cargo-deny-bin
-          cd ~/.cargo-deny-bin
-          curl -sSL -o cargo-deny.tar.gz https://github.com/EmbarkStudios/cargo-deny/releases/download/0.14.20/cargo-deny-x86_64-unknown-linux-musl.tar.gz
-          tar xzf cargo-deny.tar.gz
-          mv cargo-deny*/* .
-          rm -rf cargo-deny*
-          rm cargo-deny.tar.gz
-      - name: Add cargo-deny to PATH
-        run: echo "$HOME/.cargo-deny-bin" >> $GITHUB_PATH
+          tool: cargo-deny
       - name: Run cargo-deny checks
         run: |
-          cargo-deny check advisories
-          cargo-deny check bans
-          cargo-deny check licenses
+          cargo deny check advisories
+          cargo deny check bans
+          cargo deny check licenses
   audit:
     name: cargo-audit (CVE Check)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- replace the cargo-deny GitHub Action in the CI workflow with an explicit installation via taiki-e/install-action and run the relevant checks manually
- simplify the security workflow by reusing taiki-e/install-action for cargo-deny installation and invoking cargo deny for advisories, bans, and licenses

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e254d27824832c979bd3deb9a11eeb