### PR TITLE
Fix rust problem matcher message configuration

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -16,8 +16,7 @@
         },
         {
           "regexp": "^\\s*[|].*$",
-          "loop": true,
-          "message": 3
+          "loop": true
         }
       ]
     },
@@ -35,10 +34,9 @@
           "line": 2,
           "column": 3
         },
+        {
           "regexp": "^\\s*[|].*$",
-          "loop": true,
-          "message": 3
-  
+          "loop": true
         }
       ]
     }


### PR DESCRIPTION
## Summary
- remove duplicate message assignments from the GitHub problem matcher definition
- ensure the error and warning matchers only set the message on the first pattern

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2729817ec832c8f30457378cdc518