### PR TITLE
Fix rust problem matcher JSON structure

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -35,10 +35,10 @@
           "line": 2,
           "column": 3
         },
+        {
           "regexp": "^\\s*[|].*$",
           "loop": true,
           "message": 3
-  
         }
       ]
     }


### PR DESCRIPTION
## Summary
- ensure the rustc warning matcher pattern array contains a valid third object definition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2739f4de0832ca87e7d130c8f8295