### PR TITLE
Fix rustc problem matcher

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -1,12 +1,13 @@
 {
   "problemMatcher": [
     {
-      "owner": "rustc-error",
+      "owner": "rustc",
       "pattern": [
         {
-          "regexp": "^(error)(\\[[^\\]]+\\])?:\\s+(.*)$",
-          "message": 3,
-          "severity": 1
+          "regexp": "^(error|warning|note|help)(\\[(E\\d{4}|[\\w\\-]+)\\])?:\\s+(.*)$",
+          "severity": 1,
+          "code": 3,
+          "message": 4
         },
         {
           "regexp": "^\\s*-->\\s+([^:]+):(\\d+):(\\d+)$",
@@ -14,31 +15,10 @@
           "line": 2,
           "column": 3
         },
+        { "regexp": "^\\s*\\|$" },
         {
-          "regexp": "^\\s*[|].*$",
-          "loop": true,
-          "message": 3
-        }
-      ]
-    },
-    {
-      "owner": "rustc-warning",
-      "pattern": [
-        {
-          "regexp": "^(warning)(\\[[^\\]]+\\])?:\\s+(.*)$",
-          "message": 3,
-          "severity": 2
-        },
-        {
-          "regexp": "^\\s*-->\\s+([^:]+):(\\d+):(\\d+)$",
-          "file": 1,
-          "line": 2,
-          "column": 3
-        },
-          "regexp": "^\\s*[|].*$",
-          "loop": true,
-          "message": 3
-  
+          "regexp": "^\\s*\\|\\s*(.*)$",
+          "loop": true
         }
       ]
     }


### PR DESCRIPTION
## Summary
- replace the rustc GitHub Actions problem matcher with a single robust pattern
- capture severity, optional diagnostic code, and message from the header line only
- allow context lines to repeat without referencing missing capture groups

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e273c6c584832c96551cc12f79cc5c