### PR TITLE
Improve rust problem matcher parsing

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -16,6 +16,7 @@
           "column": 3
         },
         {
+          // This pattern matches and skips empty pipe lines in Rust error output.
           "regexp": "^\\s*\\|$"
         },
         {

--- a/.github/rust.json
+++ b/.github/rust.json
@@ -1,12 +1,13 @@
 {
   "problemMatcher": [
     {
-      "owner": "rustc-error",
+      "owner": "rustc",
       "pattern": [
         {
-          "regexp": "^(error)(\\[[^\\]]+\\])?:\\s+(.*)$",
-          "message": 3,
-          "severity": 1
+          "regexp": "^(error|warning|note|help)(\\[(E\\d{4}|[\\w\\-]+)\\])?:\\s+(.*)$",
+          "severity": 1,
+          "code": 3,
+          "message": 4
         },
         {
           "regexp": "^\\s*-->\\s+([^:]+):(\\d+):(\\d+)$",
@@ -15,27 +16,10 @@
           "column": 3
         },
         {
-          "regexp": "^\\s*[|].*$",
-          "loop": true
-        }
-      ]
-    },
-    {
-      "owner": "rustc-warning",
-      "pattern": [
-        {
-          "regexp": "^(warning)(\\[[^\\]]+\\])?:\\s+(.*)$",
-          "message": 3,
-          "severity": 2
+          "regexp": "^\\s*\\|$"
         },
         {
-          "regexp": "^\\s*-->\\s+([^:]+):(\\d+):(\\d+)$",
-          "file": 1,
-          "line": 2,
-          "column": 3
-        },
-        {
-          "regexp": "^\\s*[|].*$",
+          "regexp": "^\\s*\\|\\s*(.*)$",
           "loop": true
         }
       ]


### PR DESCRIPTION
## Summary
- consolidate rust problem matcher into a single definition that captures error, warning, note, and help severities
- add capture groups for diagnostic codes and ensure loop patterns avoid unused message fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2749ca784832c8dc363586480ef78