### PR TITLE
Adjust cargo-deny unmaintained level

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,7 @@ targets = [{ triple = "x86_64-unknown-linux-gnu" }]
 
 [advisories]
 vulnerability = "deny"
-unmaintained = "deny"
+unmaintained = "warn"
 yanked = "warn"
 notice = "warn"
 ignore = []


### PR DESCRIPTION
## Summary
- change the advisories.unmaintained level from deny to warn to match the supported cargo-deny values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27646d958832cb4bc0002a97ba95f