### PR TITLE
Fix cargo-deny config license identifiers

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,14 @@ ignore = []
 [licenses]
 unlicensed = "deny"
 allow = ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "Zlib", "Unicode-DFS-2016"]
-deny = ["AGPL-3.0", "GPL-3.0", "GPL-2.0"]
+deny = [
+    "AGPL-3.0-only",
+    "AGPL-3.0-or-later",
+    "GPL-3.0-only",
+    "GPL-3.0-or-later",
+    "GPL-2.0-only",
+    "GPL-2.0-or-later",
+]
 confidence-threshold = 0.9
 
 [bans]


### PR DESCRIPTION
## Summary
- replace deprecated SPDX identifiers in deny.toml with the valid `-only`/`-or-later` variants

## Testing
- not run (network restrictions prevented installing cargo-deny)


------
https://chatgpt.com/codex/tasks/task_e_68e279d6e340832ca8418bdd613352c4