### PR TITLE
Remove broken CI badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 ![WGX](https://img.shields.io/badge/wgx-enabled-blue)
-![security](https://github.com/hauski/hauski/actions/workflows/security.yml/badge.svg)
-![coverage](https://github.com/hauski/hauski/actions/workflows/coverage.yml/badge.svg)
 
 # HausKI — Rust-first, Offline-Default, GPU-aware
 


### PR DESCRIPTION
## Summary
- remove references to non-existent coverage and security workflow badges from the README to satisfy link checking

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2964b87f4832c85d4002118cde551