### PR TITLE
Fix rust problem matcher JSON

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -15,16 +15,14 @@
           "line": 2,
           "column": 3
         },
-        { "regexp": "^\\s*\\|$", "comment": "Matches and ignores empty context lines in Rust error output." },
+        { "regexp": "^\\s*\\|$" },
         {
-          // This pattern matches and skips empty pipe lines in Rust error output.
           "regexp": "^\\s*\\|$"
         },
         {
 
           "regexp": "^\\s*[|].*$",
-          "loop": true,
-          "message": 3
+          "loop": true
         }
       ]
     }


### PR DESCRIPTION
## Summary
- remove invalid comments and duplicate message configuration from the Rust problem matcher JSON

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2964ed08c832c9063ea0918bd397c