### PR TITLE
Fix duplicate message entry in rust problem matcher

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -21,10 +21,8 @@
           "regexp": "^\\s*\\|$"
         },
         {
-
           "regexp": "^\\s*[|].*$",
-          "loop": true,
-          "message": 3
+          "loop": true
         }
       ]
     }


### PR DESCRIPTION
## Summary
- remove the redundant `message` attribute from the looping pattern in the Rust problem matcher so the matcher is valid JSON for GitHub Actions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e29651eec0832c9c8264301b9e8dad