### PR TITLE
Ensure CI regenerates vendor snapshot before security checks

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - name: Ensure vendor snapshot
+        run: bash scripts/ensure-vendor.sh
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
       - name: Install cargo-deny (prebuilt with fallback; deduped)
@@ -103,6 +105,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - name: Ensure vendor snapshot
+        run: bash scripts/ensure-vendor.sh
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
       - name: Install cargo-audit (fresh)

--- a/scripts/ensure-vendor.sh
+++ b/scripts/ensure-vendor.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+
+if bash "${SCRIPT_DIR}/check-vendor.sh" >/dev/null 2>&1; then
+  exit 0
+fi
+
+echo "Vendor snapshot incomplete or missing; regenerating via cargo vendor..."
+mkdir -p vendor
+
+if ! (
+  export CARGO_NO_LOCAL_CONFIG=1
+  cargo vendor --locked > /tmp/cargo-vendor.log 2>&1
+); then
+  cat /tmp/cargo-vendor.log >&2
+  echo "Failed to regenerate vendor snapshot." >&2
+  exit 1
+fi
+
+cat /tmp/cargo-vendor.log
+
+# Re-run the check to ensure everything is now present.
+"${SCRIPT_DIR}/check-vendor.sh"


### PR DESCRIPTION
## Summary
- add an ensure-vendor helper that regenerates the vendor directory with `cargo vendor`
- invoke the helper from the security workflow before running the existing vendor check

## Testing
- bash scripts/ensure-vendor.sh *(fails in this environment: proxy returns HTTP 403 while contacting crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_68e29655754c832c9ad0337086b8fe9e