### PR TITLE
docs: replace ci badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ![WGX](https://img.shields.io/badge/wgx-enabled-blue)
+[![Coverage](https://img.shields.io/github/actions/workflow/status/hauski/hauski/coverage.yml?branch=main&label=Coverage)](https://github.com/hauski/hauski/actions/workflows/coverage.yml)
+[![Security](https://img.shields.io/github/actions/workflow/status/hauski/hauski/security.yml?branch=main&label=Security)](https://github.com/hauski/hauski/actions/workflows/security.yml)
 
 # HausKI — Rust-first, Offline-Default, GPU-aware
 


### PR DESCRIPTION
## Summary
- replace the coverage and security badges with shields.io endpoints so the README no longer links to 404ing GitHub badge URLs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e297f6df20832c8bd7d30df0f29d70