### PR TITLE
Fix duplicate message property in Rust problem matcher

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -23,8 +23,7 @@
         {
 
           "regexp": "^\\s*[|].*$",
-          "loop": true,
-          "message": 3
+          "loop": true
         }
       ]
     }


### PR DESCRIPTION
## Summary
- remove the duplicate `message` assignment from the custom rust problem matcher definition

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e297fa6f90832ca48cafe66971ef9e