### PR TITLE
Fix rust matcher loop message

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -17,8 +17,9 @@
         },
         { "regexp": "^\\s*\\|$" },
         {
-          "regexp": "^\\s*[|].*$",
-          "loop": true
+          "regexp": "^\\s*[|]\\s*(.*)$",
+          "loop": true,
+          "message": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary
- capture the looped message text in the rust matcher configuration
- provide the required message group reference to satisfy GitHub's matcher requirements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e29c06f71c832c9cec861b3b14291d