### PR TITLE
Fix README workflow badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![WGX](https://img.shields.io/badge/wgx-enabled-blue)
-[![Coverage](https://img.shields.io/github/actions/workflow/status/hauski/hauski/coverage.yml?branch=main&label=Coverage)](https://github.com/hauski/hauski/actions/workflows/coverage.yml)
-[![Security](https://img.shields.io/github/actions/workflow/status/hauski/hauski/security.yml?branch=main&label=Security)](https://github.com/hauski/hauski/actions/workflows/security.yml)
+[![Coverage](https://img.shields.io/github/actions/workflow/status/hauski/hauski/coverage.yml?branch=main&label=Coverage)](https://github.com/hauski/hauski/actions/workflows/coverage.yml?query=branch%3Amain)
+[![Security](https://img.shields.io/github/actions/workflow/status/hauski/hauski/security.yml?branch=main&label=Security)](https://github.com/hauski/hauski/actions/workflows/security.yml?query=branch%3Amain)
 
 # HausKI — Rust-first, Offline-Default, GPU-aware
 


### PR DESCRIPTION
## Summary
- update the coverage and security workflow badge links in the README to avoid 404 errors reported by lychee

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2b08c50e4832cafb79ed0868bf2df