### PR TITLE
Fix rust problem matcher message field

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -19,7 +19,7 @@
         {
           "regexp": "^\\s*[|]\\s*(.*)$",
           "loop": true,
-          "message": "$1"
+          "message": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary
- adjust the looped pattern in `.github/rust.json` to expose the captured message field correctly for GitHub problem matching

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3bcbc2dfc832c8f83f13e2cd0d027