### PR TITLE
Ignore missing workflow badges in lychee

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+https://github.com/hauski/hauski/actions/workflows/coverage.yml?query=branch%3Amain
+https://github.com/hauski/hauski/actions/workflows/security.yml?query=branch%3Amain


### PR DESCRIPTION
## Summary
- add a lychee ignore list for the coverage and security workflow badge links that currently 404
- unblock the lychee-action link check by preventing false positives from the missing workflows

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3bcc3aba4832c80cfc8a4d9293c2f