### PR TITLE
fix: remove invalid utoipa feature

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,7 +23,7 @@ reqwest.workspace = true
 url.workspace = true
 hauski-indexd = { path = "../indexd", version = "0.1.0" }
 tower = { version = "0.5", features = ["limit", "timeout", "util"] }
-utoipa = { version = "4", features = ["axum_extras", "macros"] }
+utoipa = { version = "4", features = ["axum_extras"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }


### PR DESCRIPTION
## Summary
- remove the invalid `macros` feature from the utoipa dependency in hauski-core

## Testing
- cargo check -p hauski-core *(fails: no matching package named `axum` found in vendor replacement registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e3be7e4748832cb37f53fa10e0d5f9