### PR TITLE
Fix rust problem matcher loop message capture

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -19,7 +19,7 @@
         {
           "regexp": "^\\s*[|]\\s*(.*)$",
           "loop": true,
-          "message": "$1"
+          "message": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary
- set the loop pattern message in `.github/rust.json` to capture the first group so the matcher satisfies GitHub's requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3be81e27c832cae6d4917a08e7f68