### PR TITLE
Refresh Cargo.lock before running cargo vendor

### DIFF
--- a/scripts/ensure-vendor.sh
+++ b/scripts/ensure-vendor.sh
@@ -10,11 +10,23 @@ if bash "${SCRIPT_DIR}/check-vendor.sh" >/dev/null 2>&1; then
   exit 0
 fi
 
-echo "Vendor snapshot incomplete or missing; regenerating via cargo vendor..."
+echo "Vendor snapshot incomplete or missing; refreshing Cargo.lock and regenerating vendor snapshot..."
 mkdir -p vendor
 
+GEN_LOCK_LOG="$(mktemp /tmp/cargo-generate-lockfile.XXXXXX.log)"
+trap 'rm -f "${GEN_LOCK_LOG}" "${LOGFILE:-}"' EXIT
+
+if ! (
+  export CARGO_NO_LOCAL_CONFIG=1
+  cargo generate-lockfile > "${GEN_LOCK_LOG}" 2>&1
+); then
+  cat "${GEN_LOCK_LOG}" >&2
+  echo "Failed to refresh Cargo.lock via cargo generate-lockfile." >&2
+  echo "Bitte aktualisiere die Lock-Datei manuell und versuche es erneut." >&2
+  exit 1
+fi
+
 LOGFILE="$(mktemp /tmp/cargo-vendor.XXXXXX.log)"
-trap 'rm -f "${LOGFILE}"' EXIT
 
 if ! (
   export CARGO_NO_LOCAL_CONFIG=1


### PR DESCRIPTION
## Summary
- update `scripts/ensure-vendor.sh` to call `cargo generate-lockfile` before invoking `cargo vendor`
- capture the output of the lockfile refresh and surface the logs when it fails
- keep temporary logs tidy by cleaning them up on exit

## Testing
- `scripts/ensure-vendor.sh`

------
https://chatgpt.com/codex/tasks/task_e_68e3c11704e8832c82f978b9dbb9bf8d