### PR TITLE
Fix GitHub matcher duplicate message property

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -18,8 +18,7 @@
         { "regexp": "^\\s*\\|$" },
         {
           "regexp": "^\\s*[|]\\s*(.*)$",
-          "loop": true,
-          "message": 1
+          "loop": true
         }
       ]
     }


### PR DESCRIPTION
## Summary
- remove the redundant message capture from the custom Rust problem matcher

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c9717338832c96448497ced8c2d5