### PR TITLE
Fix GitHub Actions rust matcher configuration

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -5,7 +5,7 @@
       "pattern": [
         {
           "regexp": "^(error|warning|note|help)(\\[(E\\d{4}|[\\w\\-]+)\\])?:\\s+(.*)$",
-          "severity": "1",
+          "severity": 1,
           "code": 3,
           "message": 4
         },
@@ -15,9 +15,11 @@
           "line": 2,
           "column": 3
         },
-        { "regexp": "^\\s*\\|$" },
         {
-          "regexp": "^\\s*[|]\\s*(.*)$",
+          "regexp": "^\\s*\\|$"
+        },
+        {
+          "regexp": "^\\s*\\|\\s*(.*)$",
           "loop": true
         }
       ]


### PR DESCRIPTION
## Summary
- update the rust problem matcher to avoid duplicate message properties
- normalize the severity capture to match the matcher schema

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3cded53e0832c80c730a5d0140f32