### PR TITLE
fix: export cargo env for vendor scripts

### DIFF
--- a/scripts/ensure-vendor.sh
+++ b/scripts/ensure-vendor.sh
@@ -6,6 +6,13 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${PROJECT_ROOT}"
 
+# Ensure Cargo ignores any user-level configuration that might interfere with the
+# vendoring process. ShellCheck previously warned (SC2030/SC2031) that setting
+# this variable inside subshells (e.g. within command invocations) would not be
+# visible to later commands. We export it once here so every Cargo invocation in
+# this script inherits the value without reassigning it in subshell context.
+export CARGO_NO_LOCAL_CONFIG=1
+
 if bash "${SCRIPT_DIR}/check-vendor.sh" >/dev/null 2>&1; then
   exit 0
 fi
@@ -16,7 +23,7 @@ mkdir -p vendor
 GEN_LOCK_LOG="$(mktemp /tmp/cargo-generate-lockfile.XXXXXX.log)"
 trap 'rm -f "${GEN_LOCK_LOG}" "${LOGFILE:-}"' EXIT
 
-if ! CARGO_NO_LOCAL_CONFIG=1 cargo generate-lockfile > "${GEN_LOCK_LOG}" 2>&1; then
+if ! cargo generate-lockfile > "${GEN_LOCK_LOG}" 2>&1; then
   cat "${GEN_LOCK_LOG}" >&2
   echo "Failed to refresh Cargo.lock via cargo generate-lockfile." >&2
   echo "Bitte aktualisiere die Lock-Datei manuell und versuche es erneut." >&2
@@ -25,7 +32,7 @@ fi
 
 LOGFILE="$(mktemp /tmp/cargo-vendor.XXXXXX.log)"
 
-if ! CARGO_NO_LOCAL_CONFIG=1 cargo vendor --locked > "${LOGFILE}" 2>&1; then
+if ! cargo vendor --locked > "${LOGFILE}" 2>&1; then
   cat "${LOGFILE}" >&2
   echo "Failed to regenerate vendor snapshot." >&2
   exit 1


### PR DESCRIPTION
## Summary
- export CARGO_NO_LOCAL_CONFIG once before running cargo commands in ensure-vendor.sh
- avoid subshell-only assignments that triggered shellcheck SC2030/SC2031 warnings
- document the intent so the variable is shared across all cargo invocations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3cef3eeb8832c830dbaa89e8f1119