### PR TITLE
Fix rust problem matcher message fields

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -13,14 +13,17 @@
           "regexp": "^\\s*-->\\s+([^:]+):(\\d+):(\\d+)$",
           "file": 1,
           "line": 2,
-          "column": 3
+          "column": 3,
+          "message": 0
         },
         {
-          "regexp": "^\\s*\\|$"
+          "regexp": "^(\\s*\\|)$",
+          "message": 1
         },
         {
           "regexp": "^\\s*\\|\\s*(.*)$",
-          "loop": true
+          "loop": true,
+          "message": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add the required message field to each pattern in the rust problem matcher
- ensure the pipe-related patterns expose capture groups for the message references

## Testing
- `jq . .github/rust.json`


------
https://chatgpt.com/codex/tasks/task_e_68e4134374dc832c97608d39246e4955